### PR TITLE
Fix policy provider

### DIFF
--- a/Server/src/Terminal.Backend.Infrastructure/Authentication/PermissionAuthorizationPolicyProvider.cs
+++ b/Server/src/Terminal.Backend.Infrastructure/Authentication/PermissionAuthorizationPolicyProvider.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Options;
 using Terminal.Backend.Infrastructure.Authentication.Requirements;
@@ -19,7 +20,8 @@ internal sealed class PermissionAuthorizationPolicyProvider : DefaultAuthorizati
             return policy;
         }
 
-        return new AuthorizationPolicyBuilder()
+        return new AuthorizationPolicyBuilder(JwtBearerDefaults.AuthenticationScheme)
+            .RequireAuthenticatedUser()
             .AddRequirements(new PermissionRequirement(policyName))
             .Build();
     }

--- a/Server/src/Terminal.Backend.Infrastructure/Extensions.cs
+++ b/Server/src/Terminal.Backend.Infrastructure/Extensions.cs
@@ -84,6 +84,7 @@ public static class Extensions
             .AddPolicy(Role.Administrator,
                 policy => { policy.AddRequirements(new RoleRequirement(Role.Administrator)); });
         services.AddScoped<IAuthorizationService, AuthorizationService>();
+        services.AddSingleton<IAuthorizationPolicyProvider, PermissionAuthorizationPolicyProvider>();
         services.AddSingleton<IAuthorizationHandler, PermissionAuthorizationHandler>();
         services.AddSingleton<IAuthorizationHandler, RoleAuthorizationHandler>();
         services.ConfigureOptions<JwtOptionsSetup>();


### PR DESCRIPTION
- Bring back PermissionAuthorizationPolicyProvider, which caused the access tokens to not be validated when using a policy provided by this class
- Fix the provider by properly validating tokens
- In the original version of the app, an expired token was considered valid!