### PR TITLE
Fix EF Core error after bumping to .NET 9

### DIFF
--- a/Server/src/Terminal.Backend.Infrastructure/DAL/Extensions.cs
+++ b/Server/src/Terminal.Backend.Infrastructure/DAL/Extensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -16,11 +17,14 @@ internal static class Extensions
         services.Configure<PostgresOptions>(configuration.GetRequiredSection(OptionsSectionName));
         var postgresOptions = configuration.GetOptions<PostgresOptions>(OptionsSectionName);
         services.AddDbContext<TerminalDbContext>(x =>
+        {
+            x.ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning));
             x.UseNpgsql(postgresOptions.ConnectionString)
                 .UseLoggerFactory(LoggerFactory.Create(b => b
                     .AddConsole()
                     .SetMinimumLevel(LogLevel.Debug)))
-                .EnableSensitiveDataLogging());
+                .EnableSensitiveDataLogging();
+        });
         services.AddScoped(typeof(IUnitOfWork<>), typeof(PostgresUnitOfWork<>));
         services.AddScoped<IProjectRepository, ProjectRepository>();
         services.AddScoped<ITagRepository, TagRepository>();

--- a/Server/test/Terminal.Backend.Architecture/Terminal.Backend.Architecture.csproj
+++ b/Server/test/Terminal.Backend.Architecture/Terminal.Backend.Architecture.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/Server/test/Terminal.Backend.Integration/Terminal.Backend.Integration.csproj
+++ b/Server/test/Terminal.Backend.Integration/Terminal.Backend.Integration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/Server/test/Terminal.Backend.Unit/Terminal.Backend.Unit.csproj
+++ b/Server/test/Terminal.Backend.Unit/Terminal.Backend.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -30,7 +30,9 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_URLS=${ASPNETCORE_URLS}
       - Postgres__ConnectionString=${Postgres__ConnectionString}
-    depends_on: ["database"]
+    depends_on:
+      database:
+        condition: service_healthy
     develop:
       watch:
         - action: rebuild
@@ -46,3 +48,8 @@ services:
       - POSTGRES_DB=${POSTGRES_DB}
       - POSTGRES_USER=${POSTGRES_USER}
     pull_policy: missing
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d $$POSTGRES_DB -U $$POSTGRES_USER"]
+      interval: 1s
+      timeout: 5s
+      retries: 5

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,15 +1,15 @@
 name: terminal
 services:
-#  reverse-proxy:
-#    container_name: terminal.reverseproxy
-#    image: nginx:latest
-#    ports:
-#      - 80:80
-#      - 443:443
-#    volumes:
-#      - ./Config/nginx:/etc/nginx/:ro
-#      - ./Config/cert:/etc/ssl/:ro
-#    depends_on: [server, client]
+  #  reverse-proxy:
+  #    container_name: terminal.reverseproxy
+  #    image: nginx:latest
+  #    ports:
+  #      - 80:80
+  #      - 443:443
+  #    volumes:
+  #      - ./Config/nginx:/etc/nginx/:ro
+  #      - ./Config/cert:/etc/ssl/:ro
+  #    depends_on: [server, client]
 
   client:
     container_name: terminal.client
@@ -34,7 +34,9 @@ services:
       - Administrator__Email=${Administrator__Email}
       - Administrator__Password=${Administrator__Password}
     restart: always
-    depends_on: ["database"]
+    depends_on:
+      database:
+        condition: service_healthy
 
   database:
     container_name: terminal.postgres
@@ -49,3 +51,8 @@ services:
       - POSTGRES_USER=${POSTGRES_USER}
     restart: always
     pull_policy: missing
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d $$POSTGRES_DB -U $$POSTGRES_USER"]
+      interval: 1s
+      timeout: 5s
+      retries: 5


### PR DESCRIPTION
in .NET 9 EF Core throws an exception as a warning when trying to apply migrations when none are available to apply, this pr fixes this and adds additional db healthchecks to compose files.

https://github.com/dotnet/efcore/issues/34431